### PR TITLE
Setup release automation

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -1,0 +1,93 @@
+name: Release Plan Review
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    types:
+      - labeled
+
+concurrency:
+  group: plan-release # only the latest one of these should ever be running
+  cancel-in-progress: true
+
+jobs:
+  check-plan:
+    name: "Check Release Plan"
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.check-release.outputs.command }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: 'main'
+      # This will only cause the `check-plan` job to have a "command" of `release`
+      # when the .release-plan.json file was changed on the last commit.
+      - id: check-release
+        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
+
+  prepare_release_notes:
+    name: Prepare Release Notes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: check-plan
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      explanation: ${{ steps.explanation.outputs.text }}
+    # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
+    # only run on labeled event if the PR has already been merged
+    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+
+    steps:
+      - uses: actions/checkout@v4
+        # We need to download lots of history so that
+        # github-changelog can discover what's changed since the last release
+        with:
+          fetch-depth: 0
+          ref: 'main'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - run: pnpm install --frozen-lockfile
+      
+      - name: "Generate Explanation and Prep Changelogs"
+        id: explanation
+        run: |
+          set +e
+          
+          pnpm release-plan prepare 2> >(tee -a stderr.log >&2)
+          
+
+          if [ $? -ne 0 ]; then
+            echo 'text<<EOF' >> $GITHUB_OUTPUT
+            cat stderr.log >> $GITHUB_OUTPUT
+            echo 'EOF' >> $GITHUB_OUTPUT
+          else
+            echo 'text<<EOF' >> $GITHUB_OUTPUT
+            jq .description .release-plan.json -r >> $GITHUB_OUTPUT
+            echo 'EOF' >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "Prepare Release using 'release-plan'"
+          labels: "internal"
+          branch: release-preview
+          title: Prepare Release
+          body: |
+            This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍
+
+            -----------------------------------------
+
+            ${{ steps.explanation.outputs.text }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+# For every push to the master branch, this checks if the release-plan was
+# updated and if it was it will publish stable npm packages based on the
+# release plan
+
+name: Publish Stable
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+
+concurrency:
+  group: publish-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-plan:
+    name: "Check Release Plan"
+    runs-on: ubuntu-latest
+    outputs:
+      command: ${{ steps.check-release.outputs.command }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: 'main'
+      # This will only cause the `check-plan` job to have a result of `success`
+      # when the .release-plan.json file was changed on the last commit. This
+      # plus the fact that this action only runs on main will be enough of a guard
+      - id: check-release
+        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
+
+  publish:
+    name: "NPM Publish"
+    runs-on: ubuntu-latest
+    needs: check-plan
+    if: needs.check-plan.outputs.command == 'release'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          # This creates an .npmrc that reads the NODE_AUTH_TOKEN environment variable
+          registry-url: 'https://registry.npmjs.org'
+      
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+      - run: pnpm install --frozen-lockfile
+      - name: npm publish
+        run: pnpm release-plan publish
+      
+        env:
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-      - run: npm install
-      - run: npm test 
+      - uses: pnpm/action-setup@v3
+      - run: pnpm install
+      - run: pnpm test 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,27 @@
+# Release Process
+
+Releases in this repo are mostly automated using [release-plan](https://github.com/embroider-build/release-plan/). Once you label all your PRs correctly (see below) you will have an automatically generated PR that updates your CHANGELOG.md file and a `.release-plan.json` that is used to prepare the release once the PR is merged.
+
+## Preparation
+
+Since the majority of the actual release process is automated, the remaining tasks before releasing are: 
+
+-  correctly labeling **all** pull requests that have been merged since the last release
+-  updating pull request titles so they make sense to our users
+
+Some great information on why this is important can be found at [keepachangelog.com](https://keepachangelog.com/en/1.1.0/), but the overall
+guiding principle here is that changelogs are for humans, not machines.
+
+When reviewing merged PR's the labels to be used are:
+
+* breaking - Used when the PR is considered a breaking change.
+* enhancement - Used when the PR adds a new feature or enhancement.
+* bug - Used when the PR fixes a bug included in a previous release.
+* documentation - Used when the PR adds or updates documentation.
+* internal - Internal changes or things that don't fit in any other category.
+
+**Note:** `release-plan` requires that **all** PRs are labeled. If a PR doesn't fit in a category it's fine to label it as `internal`
+
+## Release
+
+Once the prep work is completed, the actual release is straight forward: you just need to merge the open [Plan Release](https://github.com/proposal-signals/proposal-signals/pulls?q=is%3Apr+is%3Aopen+%22Prepare+Release%22+in%3Atitle) PR

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@tc39/ecma262-biblio": "2.1.2616",
     "ecmarkup": "^17.1.1",
-    "release-plan": "^0.8.0",
+    "release-plan": "^0.9.0",
     "vite": "^4.4.11",
     "vitest": "^0.34.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,26 +1,28 @@
 {
-  "private": true,
   "name": "proposal-signals",
+  "private": true,
   "description": "A repository for the ECMAScript Signal proposal.",
-  "scripts": {
-    "example:a": "cd examples/example-a && vite --host",
-    "start": "npm run build-loose -- --watch",
-    "test": "vitest",
-    "build": "npm run build-loose -- --strict",
-    "build-loose": "ecmarkup --load-biblio @tc39/ecma262-biblio --verbose spec.emu build/index.html --lint-spec"
-  },
   "homepage": "https://github.com/proposal-signals/proposal-signals#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/proposal-signals/proposal-signals.git"
   },
   "license": "MIT",
+  "scripts": {
+    "build": "npm run build-loose -- --strict",
+    "build-loose": "ecmarkup --load-biblio @tc39/ecma262-biblio --verbose spec.emu build/index.html --lint-spec",
+    "example:a": "cd examples/example-a && vite --host",
+    "start": "npm run build-loose -- --watch",
+    "test": "vitest"
+  },
   "devDependencies": {
     "@tc39/ecma262-biblio": "2.1.2616",
     "ecmarkup": "^17.1.1",
+    "release-plan": "^0.8.0",
     "vite": "^4.4.11",
     "vitest": "^0.34.6"
   },
+  "packageManager": "pnpm@8.15.5",
   "engines": {
     "node": ">= 12"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - '.'
+  - './packages/*'


### PR DESCRIPTION
This automation uses: [release-plan](https://github.com/embroider-build/release-plan) via [this npx boilerplate generator](https://github.com/embroider-build/create-release-plan-setup), which is a hybrid of the best parts of [release-it](https://github.com/release-it/release-it) and [changesets](https://github.com/changesets/changesets/), where:
- changelog entries are managed via _labels_ (this list is a bit hard coded, but is sufficient)
- if a maintainer can merge, they can release
- no maintainer needs to have access to npm, nor push-access to main, they only need to be able to merge PRs

The one-time setup:
- [an `NPM_TOKEN`](https://github.com/embroider-build/create-release-plan-setup?tab=readme-ov-file#create-a-npm_token)
- permission for actions to [create pull requests](https://github.com/embroider-build/create-release-plan-setup?tab=readme-ov-file#ensure-your-github-actions-token-can-create-prs)
- we'll want to enable "releases" in the settings for this repo
  - an initial git tag pushed (we can checkout the existingly published -- I've determined this to be `0.1.0` for [signal-polyfill](https://www.npmjs.com/package/signal-polyfill) which was `2024-03-31T19:18:08.630Z`, or matching commit: d811fce3c0d67529fe998f7eeaefd357f8369d01 (hopefully -- hard to tell for sure, tbh, but the commit used for publish cannot be newer than the publish timestamp)

Example:
- https://github.com/NullVoxPopuli/signal-utils/tree/main
- Feature PR: https://github.com/NullVoxPopuli/signal-utils/pull/9
  - labeled with `enhancement`
- that PR then merged  
- The release preview workflow opened this PR
  - https://github.com/NullVoxPopuli/signal-utils/pull/8
- that PR is then merged
  - [git tag](https://github.com/NullVoxPopuli/signal-utils/tree/v0.3.0-signal-utils) created
  - [github release](https://github.com/NullVoxPopuli/signal-utils/releases/tag/v0.3.0-signal-utils) created
  - [npm release](https://github.com/NullVoxPopuli/signal-utils/actions/runs/8515196237/job/23322222389#step:6:96) occurred  