### PR TITLE
Fix `this` in normal function `notify`

### DIFF
--- a/packages/signal-polyfill/src/graph.ts
+++ b/packages/signal-polyfill/src/graph.ts
@@ -174,7 +174,7 @@ export interface ReactiveNode {
    */
   producerMustRecompute(node: unknown): boolean;
   producerRecomputeValue(node: unknown): void;
-  consumerMarkedDirty(node: unknown): void;
+  consumerMarkedDirty(this: unknown): void;
 
   /**
    * Called when a signal is read within this consumer.
@@ -335,7 +335,7 @@ export function producerUpdatesAllowed(): boolean {
 export function consumerMarkDirty(node: ReactiveNode): void {
   node.dirty = true;
   producerNotifyConsumers(node);
-  node.consumerMarkedDirty?.(node);
+  node.consumerMarkedDirty?.call(node.wrapper ?? node);
 }
 
 /**

--- a/packages/signal-polyfill/src/wrapper.spec.ts
+++ b/packages/signal-polyfill/src/wrapper.spec.ts
@@ -195,6 +195,36 @@ describe("Watcher", () => {
     flushPending();
 
   });
+
+  it("provides `this` to notify as normal function", () => {
+    const mockGetPending = vi.fn();
+
+    const watcher = new Signal.subtle.Watcher(function() {
+      this.getPending();
+    });
+    watcher.getPending = mockGetPending;
+
+    const signal = new Signal.State<number>(0);
+    watcher.watch(signal);
+
+    signal.set(1);
+    expect(mockGetPending).toBeCalled();
+  });
+
+  it("can be closed in if needed in notify as an arrow function", () => {
+    const mockGetPending = vi.fn();
+
+    const watcher = new Signal.subtle.Watcher(() => {
+      watcher.getPending();
+    });
+    watcher.getPending = mockGetPending;
+
+    const signal = new Signal.State<number>(0);
+    watcher.watch(signal);
+
+    signal.set(1);
+    expect(mockGetPending).toBeCalled();
+  });
 });
 
 describe("Expected class shape", () => {

--- a/packages/signal-polyfill/src/wrapper.ts
+++ b/packages/signal-polyfill/src/wrapper.ts
@@ -206,7 +206,7 @@ export namespace subtle {
     constructor(notify: (this: Watcher) => void) {
       let node = Object.create(REACTIVE_NODE);
       node.wrapper = this;
-      node.consumerMarkedDirty = notify;
+      node.consumerMarkedDirty = () => notify.call(this);
       node.consumerIsAlwaysLive = true;
       node.consumerAllowSignalWrites = false;
       node.producerNode = [];

--- a/packages/signal-polyfill/src/wrapper.ts
+++ b/packages/signal-polyfill/src/wrapper.ts
@@ -206,7 +206,7 @@ export namespace subtle {
     constructor(notify: (this: Watcher) => void) {
       let node = Object.create(REACTIVE_NODE);
       node.wrapper = this;
-      node.consumerMarkedDirty = () => notify.call(this);
+      node.consumerMarkedDirty = notify;
       node.consumerIsAlwaysLive = true;
       node.consumerAllowSignalWrites = false;
       node.producerNode = [];


### PR DESCRIPTION
Before `notify` was called from the `ReactiveNode` context and was calling with the node as `this` instead of the expected watcher. Instead, set `consumerMarkedDirty` to a function that wraps notify with a proper call with `this`.

Also add unit tests for our expected behavior here including closure for an arrow function.

This is a follow up after https://github.com/proposal-signals/proposal-signals/pull/146 got closed
We are moving forward with different semantics than that one but the bug still needed to be fixed.