### PR TITLE
Feature: Add toJSON so that Signal.State (no matter where it exists in a bigger structure) behaves well with JSON.stringify

### DIFF
--- a/packages/signal-polyfill/src/wrapper.spec.ts
+++ b/packages/signal-polyfill/src/wrapper.spec.ts
@@ -32,7 +32,6 @@ describe("Signal.State", () => {
     const stateSignal = new Signal.State(10);
 
     expect(JSON.stringify(stateSignal)).toEqual("10");
-
   });
 });
 
@@ -51,6 +50,16 @@ describe("Computed", () => {
 
     expect(stateSignal.get()).toEqual(5);
     expect(computedSignal.get()).toEqual(10);
+  });
+
+  it("is works with JSON.stringify", () => {
+    const stateSignal = new Signal.State(10);
+    const computedSignal = new Signal.Computed(() => {
+      const f = stateSignal.get() * 2;
+      return f;
+    });
+
+    expect(JSON.stringify(computedSignal)).toEqual("20");
   });
 });
 

--- a/packages/signal-polyfill/src/wrapper.spec.ts
+++ b/packages/signal-polyfill/src/wrapper.spec.ts
@@ -27,6 +27,13 @@ describe("Signal.State", () => {
 
     expect(stateSignal.get()).toEqual(10);
   });
+
+  it("is works with JSON.stringify", () => {
+    const stateSignal = new Signal.State(10);
+
+    expect(JSON.stringify(stateSignal)).toEqual("10");
+
+  });
 });
 
 describe("Computed", () => {
@@ -107,7 +114,7 @@ describe("Watcher", () => {
       output = stateSignal.get();
       computedOutput = computedSignal.get();
       calls++;
-      return () => {};
+      return () => { };
     });
 
     // The signal is now watched
@@ -188,7 +195,7 @@ describe("Watcher", () => {
     // Adding any other effect after an unwatch should work as expected
     const destructor2 = effect(() => {
       output = stateSignal.get();
-      return () => {};
+      return () => { };
     });
 
     stateSignal.set(300);
@@ -336,8 +343,8 @@ describe("liveness", () => {
     expect(watchedSpy).not.toBeCalled();
     expect(unwatchedSpy).not.toBeCalled();
 
-    const w = new Signal.subtle.Watcher(() => {});
-    const w2 = new Signal.subtle.Watcher(() => {});
+    const w = new Signal.subtle.Watcher(() => { });
+    const w2 = new Signal.subtle.Watcher(() => { });
 
     w.watch(computed);
     expect(watchedSpy).toBeCalledTimes(1);
@@ -369,7 +376,7 @@ describe("liveness", () => {
     expect(watchedSpy).not.toBeCalled();
     expect(unwatchedSpy).not.toBeCalled();
 
-    const w = new Signal.subtle.Watcher(() => {});
+    const w = new Signal.subtle.Watcher(() => { });
     w.watch(c);
     expect(watchedSpy).toBeCalledTimes(1);
     expect(unwatchedSpy).not.toBeCalled();
@@ -419,7 +426,7 @@ describe("Errors", () => {
       n++;
       throw s.get();
     });
-    const w = new Signal.subtle.Watcher(() => {});
+    const w = new Signal.subtle.Watcher(() => { });
     w.watch(c);
 
     expect(n).toBe(0);
@@ -502,7 +509,7 @@ describe("Pruning", () => {
     const c2 = new Signal.Computed(() => (n2++, c.get(), 5));
     let n3 = 0;
     const c3 = new Signal.Computed(() => (n3++, c2.get()));
-    const w = new Signal.subtle.Watcher(() => {});
+    const w = new Signal.subtle.Watcher(() => { });
     w.watch(c3);
 
     expect(n).toBe(0);
@@ -676,7 +683,7 @@ describe("Custom equality", () => {
 describe("Receivers", () => {
   it("is this for computed", () => {
     let receiver;
-    const c = new Signal.Computed(function () {
+    const c = new Signal.Computed(function() {
       receiver = this;
     });
     expect(c.get()).toBe(undefined);
@@ -694,7 +701,7 @@ describe("Receivers", () => {
     });
     expect(r1).toBe(undefined);
     expect(r2).toBe(undefined);
-    const w = new Signal.subtle.Watcher(() => {});
+    const w = new Signal.subtle.Watcher(() => { });
     w.watch(s);
     expect(r1).toBe(s);
     expect(r2).toBe(undefined);
@@ -731,7 +738,7 @@ describe("Dynamic dependencies", () => {
       return str;
     });
     if (live) {
-      const w = new Signal.subtle.Watcher(() => {});
+      const w = new Signal.subtle.Watcher(() => { });
       w.watch(computed);
     }
     expect(computed.get()).toBe("abcdefgh");
@@ -920,8 +927,8 @@ describe("type checks", () => {
   it("checks types in methods", () => {
     let x = {};
     let s = new Signal.State(1);
-    let c = new Signal.Computed(() => {});
-    let w = new Signal.subtle.Watcher(() => {});
+    let c = new Signal.Computed(() => { });
+    let w = new Signal.subtle.Watcher(() => { });
 
     expect(() => Signal.State.prototype.get.call(x)).toThrowError(TypeError);
     expect(Signal.State.prototype.get.call(s)).toBe(1);

--- a/packages/signal-polyfill/src/wrapper.ts
+++ b/packages/signal-polyfill/src/wrapper.ts
@@ -126,6 +126,10 @@ export class Computed<T> {
     }
   }
 
+  toJSON() {
+    return this.get();
+  }
+
   get(): T {
     if (!isComputed(this))
       throw new TypeError(

--- a/packages/signal-polyfill/src/wrapper.ts
+++ b/packages/signal-polyfill/src/wrapper.ts
@@ -71,6 +71,10 @@ export class State<T> {
     }
   }
 
+  toJSON() {
+    return this.get();
+  }
+
   public get(): T {
     if (!isState(this))
       throw new TypeError(


### PR DESCRIPTION
title.

Idk if folks would want _more_ information included, but _I_ think this makes sense -- it's a reactive version of a value, and this toJSON implementation essentially just unwraps that which JSON doesn't care about