### PR TITLE
chore: remove example:a script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "name": "proposal-signals",
   "description": "A repository for the ECMAScript Signal proposal.",
   "scripts": {
-    "example:a": "cd examples/example-a && vite --host",
     "start": "npm run build-loose -- --watch",
     "test": "vitest",
     "build": "npm run build-loose -- --strict",


### PR DESCRIPTION
I see the `examples/` has been removed in [https://github.com/tc39/proposal-signals/commit/aa03e0cbc9e6e6f8c1db35a30a6ad6376dc0a404](url)