### PR TITLE
Resolves https://github.com/tc39/proposal-signals/issues/174

### DIFF
--- a/packages/signal-polyfill/src/graph.ts
+++ b/packages/signal-polyfill/src/graph.ts
@@ -6,11 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Required as the signals library is in a separate package, so we need to explicitly ensure the
-// global `ngDevMode` type is defined.
-declare const ngDevMode: boolean|undefined;
-
-
 /**
  * The currently active consumer `ReactiveNode`, if running code in a reactive context.
  *
@@ -215,7 +210,7 @@ interface ProducerNode extends ReactiveNode {
 export function producerAccessed(node: ReactiveNode): void {
   if (inNotificationPhase) {
     throw new Error(
-        typeof ngDevMode !== 'undefined' && ngDevMode ?
+        import.meta?.env?.DEBUG ?
             `Assertion error: signal read during notification phase` :
             '');
   }
@@ -462,7 +457,7 @@ export function producerRemoveLiveConsumerAtIndex(node: ReactiveNode, idx: numbe
   assertProducerNode(node);
   assertConsumerNode(node);
 
-  if (typeof ngDevMode !== 'undefined' && ngDevMode && idx >= node.liveConsumerNode.length) {
+  if (import.meta?.env?.DEBUG && idx >= node.liveConsumerNode.length) {
     throw new Error(`Assertion error: active consumer index ${idx} is out of bounds of ${
         node.liveConsumerNode.length} consumers)`);
   }

--- a/packages/signal-polyfill/src/import-meta-env.d.ts
+++ b/packages/signal-polyfill/src/import-meta-env.d.ts
@@ -1,0 +1,5 @@
+interface ImportMeta {
+  env?: {
+    DEBUG?: boolean;
+  };
+}

--- a/packages/signal-polyfill/src/signal.ts
+++ b/packages/signal-polyfill/src/signal.ts
@@ -10,10 +10,6 @@ import {defaultEquals, ValueEqualityFn} from './equality.js';
 import {throwInvalidWriteToSignalError} from './errors.js';
 import {producerAccessed, producerIncrementEpoch, producerNotifyConsumers, producerUpdatesAllowed, REACTIVE_NODE, ReactiveNode, SIGNAL} from './graph.js';
 
-// Required as the signals library is in a separate package, so we need to explicitly ensure the
-// global `ngDevMode` type is defined.
-declare const ngDevMode: boolean|undefined;
-
 /**
  * If set, called after `WritableSignal`s are updated.
  *

--- a/packages/signal-polyfill/src/wrapper.spec.ts
+++ b/packages/signal-polyfill/src/wrapper.spec.ts
@@ -1018,5 +1018,5 @@ describe("currentComputed", () => {
 // - The code for the callbacks (for reading signals and running watches)
 // - Paths around writes being prohibited during computed/effect
 // - Setters for various hooks
-// - ngDevMode
+// - import.meta.env.DEBUG
 // - Some predicates/getters for convenience, e.g., isReactive


### PR DESCRIPTION
Replace `ngDevMode` references with a framework-agnostic `import.meta?.env?.DEBUG` value