### PR TITLE
Add GC tests

### DIFF
--- a/packages/signal-polyfill/src/tsconfig.json
+++ b/packages/signal-polyfill/src/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "rootDir": "./",
+    "pretty": true,
+    "moduleResolution": "node",
+    "module": "ESNext",
+    "target": "ES2022",
+    "noEmit": true,
+    "lib": ["DOM", "ES2021"],
+    "strict": true,
+    "composite": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/packages/signal-polyfill/vite.config.ts
+++ b/packages/signal-polyfill/vite.config.ts
@@ -11,7 +11,15 @@ export default defineConfig({
     lib: {
       entry,
       formats: ["es"],
-      fileName: "index"
-    }
-  }
+      fileName: "index",
+    },
+  },
+  test: {
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        execArgv: ["--expose_gc"],
+      },
+    },
+  },
 });


### PR DESCRIPTION
This adds 3 new tests, 2 of which currently fail:
- collects out of scope consumers (Pass): Ensures abandoned Computed's (not consumed by anything, and no references) won't cause a memory leak.
- collects inactive dynamic sources (Fail): Ensures old dynamic sources that get replaced can be collected. The impacts of this not passing are bounded, so it's more of a memory deficiency than a leak. Since the consumer isn't dirty some might believe this to be expected.
- collects inactive dynamic sources after update (Fail): Ensures old dynamic sources that get replaced can be collected after a update that could have marked the consumer dirty.

The impacts of the two failing tests are bounded, so it's more of a memory deficiency than a full on leak.

Required updating viteconfig to expose gc, doesn't appear to work inside the default pool type. Also `WeakRef` wasn't usable in spec files, hence adding the nested tsconfig. Doing so enforced strict mode on the spec file so a few further updates to the types were made to appease the type checker.

