### PR TITLE
Remove `ngDevMode` condition on error message

### DIFF
--- a/packages/signal-polyfill/src/graph.ts
+++ b/packages/signal-polyfill/src/graph.ts
@@ -214,10 +214,7 @@ interface ProducerNode extends ReactiveNode {
  */
 export function producerAccessed(node: ReactiveNode): void {
   if (inNotificationPhase) {
-    throw new Error(
-        typeof ngDevMode !== 'undefined' && ngDevMode ?
-            `Assertion error: signal read during notification phase` :
-            '');
+    throw new Error('Assertion error: signal read during notification phase');
   }
 
   if (activeConsumer === null) {


### PR DESCRIPTION
Error messages shouldn't differ like that based on environment. It's also useful outside of Angular.