### PR TITLE
Remove Angular-specific code

### DIFF
--- a/packages/signal-polyfill/src/graph.ts
+++ b/packages/signal-polyfill/src/graph.ts
@@ -214,10 +214,7 @@ interface ProducerNode extends ReactiveNode {
  */
 export function producerAccessed(node: ReactiveNode): void {
   if (inNotificationPhase) {
-    throw new Error(
-        typeof ngDevMode !== 'undefined' && ngDevMode ?
-            `Assertion error: signal read during notification phase` :
-            '');
+    throw new Error('Assertion error: signal read during notification phase');
   }
 
   if (activeConsumer === null) {

--- a/packages/signal-polyfill/src/graph.ts
+++ b/packages/signal-polyfill/src/graph.ts
@@ -6,10 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Required as the signals library is in a separate package, so we need to explicitly ensure the
-// global `ngDevMode` type is defined.
-declare const ngDevMode: boolean|undefined;
-
 
 /**
  * The currently active consumer `ReactiveNode`, if running code in a reactive context.
@@ -459,7 +455,7 @@ export function producerRemoveLiveConsumerAtIndex(node: ReactiveNode, idx: numbe
   assertProducerNode(node);
   assertConsumerNode(node);
 
-  if (typeof ngDevMode !== 'undefined' && ngDevMode && idx >= node.liveConsumerNode.length) {
+  if (idx >= node.liveConsumerNode.length) {
     throw new Error(`Assertion error: active consumer index ${idx} is out of bounds of ${
         node.liveConsumerNode.length} consumers)`);
   }

--- a/packages/signal-polyfill/src/signal.ts
+++ b/packages/signal-polyfill/src/signal.ts
@@ -10,10 +10,6 @@ import {defaultEquals, ValueEqualityFn} from './equality.js';
 import {throwInvalidWriteToSignalError} from './errors.js';
 import {producerAccessed, producerIncrementEpoch, producerNotifyConsumers, producerUpdatesAllowed, REACTIVE_NODE, ReactiveNode, SIGNAL} from './graph.js';
 
-// Required as the signals library is in a separate package, so we need to explicitly ensure the
-// global `ngDevMode` type is defined.
-declare const ngDevMode: boolean|undefined;
-
 /**
  * If set, called after `WritableSignal`s are updated.
  *

--- a/packages/signal-polyfill/src/wrapper.spec.ts
+++ b/packages/signal-polyfill/src/wrapper.spec.ts
@@ -1048,5 +1048,4 @@ describe("currentComputed", () => {
 // - The code for the callbacks (for reading signals and running watches)
 // - Paths around writes being prohibited during computed/effect
 // - Setters for various hooks
-// - ngDevMode
 // - Some predicates/getters for convenience, e.g., isReactive


### PR DESCRIPTION
Fixes #174 and depends on #193 (it contains that commit). Closes #175 - consider this as an always-checking alternative to it.