### PR TITLE
Suggestion: don't recompute when dependent signals come back to previous values used for last computation

### DIFF
--- a/packages/signal-polyfill/src/wrapper.spec.ts
+++ b/packages/signal-polyfill/src/wrapper.spec.ts
@@ -558,6 +558,35 @@ describe("Pruning", () => {
 
     expect(w.getPending().length).toBe(0);
   });
+  it("does not recompute when the dependent values go back to the ones used for last computation", () => {
+    const s = new Signal.State(0);
+    let n = 0;
+    const c = new Signal.Computed(() => (n++, s.get()));
+    expect(n).toBe(0);
+    expect(c.get()).toBe(0);
+    expect(n).toBe(1);
+    s.set(1);
+    expect(n).toBe(1);
+    s.set(0);
+    expect(n).toBe(1);
+    expect(c.get()).toBe(0); // the last time c was computed was with s = 0, no need to recompute
+    expect(n).toBe(1);
+  });
+  it("does not recompute when the dependent values go back to the ones used for last computation (with extra computed)", () => {
+    const s = new Signal.State(0);
+    let n = 0;
+    const extra = new Signal.Computed(() => s.get());
+    const c = new Signal.Computed(() => (n++, extra.get()));
+    expect(n).toBe(0);
+    expect(c.get()).toBe(0);
+    expect(n).toBe(1);
+    s.set(1);
+    expect(n).toBe(1);
+    s.set(0);
+    expect(n).toBe(1);
+    expect(c.get()).toBe(0); // the last time c was computed was with s = 0, no need to recompute
+    expect(n).toBe(1);
+  });
 });
 
 describe("Prohibited contexts", () => {


### PR DESCRIPTION
Hello,
I am a maintainer of the [tansu](https://github.com/AmadeusITGroup/tansu) signal library.
As I was exploring how to re-implement `tansu` with the `signal-polyfill` package (as I am hoping it will bring better interoperability with other signal libraries), I came across the following simple use case which does not match my expectations (and does not match either the behavior we implemented in tansu).
I am opening this PR to discuss it. It does not (yet) contain any fix, just the test cases. One fails and the other one succeeds:

Here is the failing use case:
```ts
let n = 0;
const s = new Signal.State(0);
const c = new Signal.Computed(() => (n++, s.get()));
c.get(); // this triggers a computation of c (so n passes from 0 to 1)
s.set(1); // this does not trigger anything because the computation of c is lazy
s.set(0); // let's come back to the previous value of s
c.get(); // if we recompute c, there is no need to call the function as the last time c was computed was with s = 0
expect(n).toBe(1); // so I am expecting n to still be 1
// but this test fails: there is an (unneeded) re-computation
```

Here is a small variation of the previous case, with an extra intermediate computed signal, which prevents the re-computation of c:
```ts
let n = 0;
const s = new Signal.State(0);
const extra = new Signal.Computed(() => s.get());
const c = new Signal.Computed(() => (n++, extra.get()));
c.get(); // this triggers a computation of c (so n passes from 0 to 1)
s.set(1); // this does not trigger anything because the computation of c is lazy
s.set(0); // let's come back to the previous value of s
c.get(); // if we recompute c, there is no need to call the function as the last time c was computed was with s = 0
expect(n).toBe(1); // so I am expecting n to still be 1
// this test succeeds
```

I believe we should not have to add intermediate computed signals to prevent unneeded re-computations.
In addition to checking the version number of dependent signals, I was expecting the algorithm to also compare the values with the previous values (using the provided equal function) before calling the re-computation function.

What do you think?