### PR TITLE
Make clear that `Signal.State` has no state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,7 +469,6 @@ Signal algorithms need to reference certain global state. This state is global f
 1. Set this Signal's `watched` to options?.[Signal.subtle.watched]
 1. Set this Signal's `unwatched` to options?.[Signal.subtle.unwatched]
 1. Set this Signal's `sinks` to the empty set
-1. Set `state` to `~clean~`.
 
 #### Method: `Signal.State.prototype.get()`
 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Signal algorithms need to reference certain global state. This state is global f
 - `unwatched`: The callback to be called when the signal is no longer observed by an effect
 - `sinks`: Set of watched signals which depend on this one
 
-#### Constructor: `Signal(initialValue, options)`
+#### Constructor: `Signal.State(initialValue, options)`
 
 1. Set this Signal's `value` to `initialValue`.
 1. Set this Signal's `equals` to options?.equals

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ With [AsyncContext](https://github.com/tc39/proposal-async-context), the callbac
 
 #### Method: `Signal.subtle.Watcher.prototype.getPending()`
 
-1. Return an Array containing the subset of `signals` which are in the state `dirty` or `pending`.
+1. Return an Array containing the subset of `signals` which are Computed Signals in the states `~dirty~` or `~pending~`.
 
 ### Method: `Signal.subtle.untrack(cb)`
 

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ With [AsyncContext](https://github.com/tc39/proposal-async-context), the callbac
 1. If `computing` is not `undefined`, add this Signal to `computing`'s `sources` set.
 1. NOTE: We do not add `computing` to this Signal's `sinks` set until/unless it becomes watched by a Watcher.
 1. If this Signal's state is `~dirty~` or `~checked~`: Repeat the following steps until this Signal is `~clean~`:
-    1. Recurse up via `sources` to find the deepest, left-most (i.e. earliest observed) recursive source which is marked `~dirty~` (cutting off search when hitting a `~clean~` Signal, and including this Signal as the last thing to search).
+    1. Recurse up via `sources` to find the deepest, left-most (i.e. earliest observed) recursive source which is a Computed Signal marked `~dirty~` (cutting off search when hitting a `~clean~` Computed Signal, and including this Computed Signal as the last thing to search).
     1. Perform the "recalculate dirty computed Signal" algorithm on that Signal.
 1. At this point, this Signal's state will be `~clean~`, and no recursive sources will be `~dirty~` or `~checked~`. Return the Signal's `value`. If the value is an exception, rethrow that exception.
 


### PR DESCRIPTION
There are a couple of references to signal states which only apply to computed signals updated here.