### PR TITLE
README.md: bug in Signal.subtle.Watcher.prototype.watch pseudocode

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ With [AsyncContext](https://github.com/tc39/proposal-async-context), the callbac
     1. If this was the first sink, then recurse up to sources to add that signal as a sink.
     1. Set `frozen` to true.
     1. Call the `watched` callback if it exists.
-    1. Restore `frozen` to true.
+    1. Restore `frozen` to false.
 1. If the Signal's `state` is `~waiting~`, then set it to `~watching~`.
 
 #### Method: `Signal.subtle.Watcher.prototype.unwatch(...signals)`


### PR DESCRIPTION
Signal.subtle.Watcher.prototype.watch step 4.v should restore frozen to `false` but it was written as `true`
